### PR TITLE
fix: increase MAX_CONTENT_LENGTH to 100MB

### DIFF
--- a/skill_hub/server/app.py
+++ b/skill_hub/server/app.py
@@ -42,6 +42,8 @@ def create_app(config: Config) -> Quart:
     # Configure app settings
     app.config["DEBUG"] = config.debug
     app.config["SECRET_KEY"] = config.auth_token  # Use auth token as secret key
+    app.config["MAX_CONTENT_LENGTH"] = 100 * 1024 * 1024  # 100 MB limit
+
     
     # Register error handlers
     register_error_handlers(app)


### PR DESCRIPTION
Fixes the "413 Request Entity Too Large" error when uploading large zip files to the add_skill endpoint. The default Quart/Flask limit is 16MB, which is too small for many skill packages.