### PR TITLE
refactor(skill_service): extract hardcoded COS base_url to env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ SKILL_HUB_API_PREFIX=/api
 SKILL_HUB_COS_SECRET_ID=YOUR_COS_SECRET_ID
 SKILL_HUB_COS_SECRET_KEY=YOUR_COS_SECRET_KEY
 SKILL_HUB_COS_ENDPOINT=YOUR_COS_ENDPOINT
+# Public base URL for COS-hosted assets (e.g. skill icons). No trailing slash.
+# Example: https://your-bucket-12345.cos.ap-beijing.myqcloud.com
+SKILL_HUB_COS_BASE_URL=https://your-bucket-12345.cos.ap-beijing.myqcloud.com

--- a/skill_hub/config/config.py
+++ b/skill_hub/config/config.py
@@ -37,6 +37,8 @@ class Config:
     cos_secret_id: str = field(default="")
     cos_secret_key: str = field(default="")
     cos_endpoint: str = field(default="")
+    # Public base URL used to serve COS-hosted assets (e.g. skill icons)
+    cos_base_url: str = field(default="")
 
     def __post_init__(self):
         """Validate configuration after initialization"""
@@ -59,6 +61,7 @@ class Config:
         env_cos_secret_id = os.getenv("SKILL_HUB_COS_SECRET_ID")
         env_cos_secret_key = os.getenv("SKILL_HUB_COS_SECRET_KEY")
         env_cos_endpoint = os.getenv("SKILL_HUB_COS_ENDPOINT")
+        env_cos_base_url = os.getenv("SKILL_HUB_COS_BASE_URL")
         
         # Apply environment variables only if not explicitly set in constructor
         # and environment variable exists
@@ -115,7 +118,15 @@ class Config:
             
         if not self.cos_endpoint and env_cos_endpoint:
             self.cos_endpoint = env_cos_endpoint
-        
+
+        if not self.cos_base_url and env_cos_base_url:
+            self.cos_base_url = env_cos_base_url
+
+        # Normalize cos_base_url by stripping any trailing slash to avoid
+        # double-slashes when concatenating with object keys.
+        if self.cos_base_url:
+            self.cos_base_url = self.cos_base_url.rstrip("/")
+
         # Validate required fields
         if not self.auth_token:
             raise ValueError("SKILL_HUB_AUTH_TOKEN environment variable must be set")

--- a/skill_hub/services/skill_service.py
+++ b/skill_hub/services/skill_service.py
@@ -1,6 +1,8 @@
 """Skill service for database CRUD operations"""
 
+import os
 import uuid
+import logging
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 from sqlalchemy import select, update, delete, desc, func
@@ -8,6 +10,29 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from skill_hub.models.skill import Skill
 from skill_hub.api.exceptions import NotFoundException, ConflictException
+
+logger = logging.getLogger(__name__)
+
+# Default path (relative to the COS base URL) of the fallback icon used when a
+# skill record does not provide one.
+_DEFAULT_ICON_PATH = "skill-hub/icons/default.png"
+
+
+def _get_cos_base_url() -> str:
+    """Resolve the public base URL for COS-hosted assets.
+
+    The value is read from the ``SKILL_HUB_COS_BASE_URL`` environment variable
+    (also exposed via :class:`skill_hub.config.config.Config.cos_base_url`).
+    Any trailing slash is stripped so callers can safely concatenate with an
+    object key using ``f"{base_url}/{key}"``.
+    """
+    base_url = os.getenv("SKILL_HUB_COS_BASE_URL", "").strip()
+    if not base_url:
+        logger.warning(
+            "SKILL_HUB_COS_BASE_URL is not configured; skill icon URLs will be "
+            "returned as relative paths."
+        )
+    return base_url.rstrip("/")
 
 
 class SkillService:
@@ -181,14 +206,14 @@ class SkillService:
             cloned_skill = Skill(**skill_dict)
             cloned_skills.append(cloned_skill)
             
-        # Replace empty icon with default
-        base_url = 'https://sudoclaw-1309794936.cos.ap-beijing.myqcloud.com'
-        default_icon = 'skill-hub/icons/default.png'
+        # Replace empty icon with default. The base URL is sourced from the
+        # SKILL_HUB_COS_BASE_URL env var (see .env.example / Config) rather
+        # than being hardcoded here.
+        base_url = _get_cos_base_url()
+        default_icon = _DEFAULT_ICON_PATH
         for skill in cloned_skills:
-            if not skill.icon:
-                skill.icon = f"{base_url}/{default_icon}"
-            else:
-                skill.icon = f"{base_url}/{skill.icon}"
+            icon_path = skill.icon if skill.icon else default_icon
+            skill.icon = f"{base_url}/{icon_path}" if base_url else icon_path
                 
         has_more = len(cloned_skills) > limit
         if has_more:


### PR DESCRIPTION
## Summary

- Replace the hardcoded COS base URL in `SkillService.list_all_cursor` with a value loaded from a new `SKILL_HUB_COS_BASE_URL` environment variable.
- Add a matching `cos_base_url` field to `Config` and document the new env var in `.env.example`.
- Emit a warning and fall back to relative icon paths if the env var is not configured, so deployments are never silently tied to a specific bucket.

Resolves #6.

## Test plan

- [ ] Set `SKILL_HUB_COS_BASE_URL` in `.env` and verify `GET /skills/cursor` returns icons prefixed with that URL.
- [ ] Unset `SKILL_HUB_COS_BASE_URL` and verify the warning is logged and icons are returned as relative paths.

Generated with [Claude Code](https://claude.ai/code)