### PR TITLE
feat: add Dockerfile and docker-compose for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,90 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# GitHub
+.github
+
+# Python cache / build artifacts
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+logs/
+
+# Test / coverage
+.coverage
+htmlcov/
+.pytest_cache/
+.tox/
+.mypy_cache/
+.pyre/
+.pytype/
+cython_debug/
+
+# Local data / user-generated artifacts
+data/
+/spider/
+/samples/
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Misc
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1.6
+
+# =========================
+# Stage 1: builder
+# =========================
+FROM python:3.11-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install build dependencies (needed for some Python packages that may compile from source)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies into an isolated prefix for copy into the final image
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --prefix=/install -r requirements.txt
+
+
+# =========================
+# Stage 2: runtime
+# =========================
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    SKILL_HUB_HOST=0.0.0.0 \
+    SKILL_HUB_PORT=8080 \
+    SKILL_HUB_DATA_DIR=/app/data \
+    SKILL_HUB_LOG_LEVEL=INFO \
+    SKILL_HUB_API_PREFIX=/api
+
+# Install runtime system dependencies (libpq for psycopg2, curl for healthcheck)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq5 \
+        curl \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user to run the application
+RUN groupadd --system --gid 1000 skillhub \
+    && useradd --system --uid 1000 --gid skillhub --create-home --shell /bin/bash skillhub
+
+WORKDIR /app
+
+# Copy installed Python dependencies from the builder stage
+COPY --from=builder /install /usr/local
+
+# Copy application source
+COPY --chown=skillhub:skillhub . /app
+
+# Ensure the data directory exists and is writable
+RUN mkdir -p /app/data \
+    && chown -R skillhub:skillhub /app \
+    && chmod +x /app/start_server.sh
+
+USER skillhub
+
+EXPOSE 8080
+
+# Basic healthcheck hitting the /health endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${SKILL_HUB_PORT:-8080}/health" || exit 1
+
+# Use tini as PID 1 for proper signal handling
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/start_server.sh"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,56 @@ curl -X POST http://localhost:8080/api/skills \
   }'
 ```
 
+## Docker
+
+Skill Hub ships with a production-ready `Dockerfile` (multi-stage build, non-root user, tini as PID 1, healthcheck) and a `docker-compose.yml` that also provisions a PostgreSQL database for local use.
+
+### Build the image
+
+```bash
+docker build -t skill-hub:latest .
+```
+
+### Run the container
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e SKILL_HUB_AUTH_TOKEN=your-secret-token \
+  -e SKILL_HUB_DATABASE_URL=postgresql://user:pass@host:5432/skill_hub \
+  -v skill-hub-data:/app/data \
+  --name skill-hub \
+  skill-hub:latest
+```
+
+All configuration options in the [Configuration Options](#configuration-options) table can be passed via `-e` environment variables. The container listens on port `8080` and runs as the non-root `skillhub` user.
+
+### Run with docker-compose (app + PostgreSQL)
+
+```bash
+# Optional: override defaults by exporting variables or creating a .env file
+export SKILL_HUB_AUTH_TOKEN=your-secret-token
+
+docker compose up -d --build
+```
+
+This will start a PostgreSQL 16 instance and the Skill Hub API server wired together on an internal network. Data is persisted to the `pgdata` and `skill-hub-data` named volumes.
+
+To stop and remove the stack:
+
+```bash
+docker compose down          # keep volumes
+docker compose down -v       # also remove volumes (destructive)
+```
+
+### Publishing the image
+
+You can tag and push the image to any container registry:
+
+```bash
+docker tag skill-hub:latest ghcr.io/<owner>/skill-hub:latest
+docker push ghcr.io/<owner>/skill-hub:latest
+```
+
 ## Development
 
 ### Running Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: skill-hub-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-skill_hub}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-skill_hub}
+      POSTGRES_DB: ${POSTGRES_DB:-skill_hub}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-skill_hub} -d ${POSTGRES_DB:-skill_hub}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  skill-hub:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: skill-hub:latest
+    container_name: skill-hub
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SKILL_HUB_HOST: 0.0.0.0
+      SKILL_HUB_PORT: 8080
+      SKILL_HUB_DEBUG: "false"
+      SKILL_HUB_AUTH_TOKEN: ${SKILL_HUB_AUTH_TOKEN:-change-me-please}
+      SKILL_HUB_DATABASE_URL: postgresql://${POSTGRES_USER:-skill_hub}:${POSTGRES_PASSWORD:-skill_hub}@db:5432/${POSTGRES_DB:-skill_hub}
+      SKILL_HUB_DATABASE_POOL_SIZE: "10"
+      SKILL_HUB_DATABASE_MAX_OVERFLOW: "20"
+      SKILL_HUB_DATABASE_POOL_RECYCLE: "3600"
+      SKILL_HUB_DATA_DIR: /app/data
+      SKILL_HUB_LOG_LEVEL: INFO
+      SKILL_HUB_API_PREFIX: /api
+    ports:
+      - "${SKILL_HUB_PORT:-8080}:8080"
+    volumes:
+      - skill-hub-data:/app/data
+
+volumes:
+  pgdata:
+  skill-hub-data:


### PR DESCRIPTION
## Summary
- Add multi-stage `Dockerfile` (python:3.11-slim, non-root user, tini, healthcheck)
- Add `.dockerignore` to shrink build context and avoid leaking local env/data
- Add `docker-compose.yml` bringing up skill-hub + PostgreSQL 16 with persistent volumes
- Document Docker build/run/compose workflows in `README.md`

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)