### PR TITLE
ci: build docker image on remote server instead of ghcr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,75 +5,49 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha,format=short
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   deploy:
-    needs: build-and-push-image
     runs-on: ubuntu-latest
 
     steps:
-      - name: Execute SSH Commands to Deploy
+      - name: Execute SSH Commands to Build and Deploy
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            # Log into GitHub Container Registry
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+            set -e  # Exit immediately if a command exits with a non-zero status.
 
-            # Navigate to deployment directory
+            # Prepare directories
             cd ${{ secrets.DEPLOY_PATH }}
 
-            # Pull the latest image
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            # Create a temporary directory for the source code
+            TEMP_DIR=$(mktemp -d -p ${{ secrets.DEPLOY_PATH }} source-XXXXXX)
+            echo "Working in temp directory: $TEMP_DIR"
+
+            # Clone the repository
+            git clone -b main https://github.com/${{ github.repository }}.git $TEMP_DIR
+            cd $TEMP_DIR
+
+            # Build the Docker image locally on the server
+            echo "Building Docker image..."
+            docker build -t skill-hub:latest .
+
+            # Copy docker-compose.prod.yml to the DEPLOY_PATH
+            cp docker-compose.prod.yml ${{ secrets.DEPLOY_PATH }}/
+
+            # Return to DEPLOY_PATH
+            cd ${{ secrets.DEPLOY_PATH }}
 
             # Recreate containers with the new image
-            # Note: This assumes you are using docker-compose.prod.yml on the server
-            docker compose -f docker-compose.prod.yml pull
+            echo "Starting containers..."
             docker compose -f docker-compose.prod.yml up -d
 
-            # Clean up old images to save disk space
+            # Clean up the temporary source code directory
+            echo "Cleaning up source code..."
+            rm -rf $TEMP_DIR
+
+            # Clean up dangling and unused images to save disk space
+            echo "Pruning unused Docker images..."
             docker image prune -af

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   skill-hub:
-    image: ghcr.io/${GITHUB_REPOSITORY:-sudoprivacy/skill-hub}:latest
+    image: skill-hub:latest
     container_name: skill-hub
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Updated deploy.yml to directly connect to the remote server via SSH, clone the latest code into a temporary directory, and perform the Docker build locally on the target machine. Once the container starts, the temporary code directory is removed to save space.

Updated docker-compose.prod.yml to use the locally built image.