### PR TITLE
fix(ci): address permission denied reading tar file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,10 @@ jobs:
             # Navigate to deployment directory
             cd ${{ secrets.DEPLOY_PATH }}
 
+            # Fix permissions (scp might create files with strict permissions)
+            echo "Adjusting file permissions..."
+            chmod 644 skill-hub-latest.tar docker-compose.prod.yml
+
             # Load the Docker image from the tar archive
             echo "Loading Docker image from archive..."
             docker load -i skill-hub-latest.tar


### PR DESCRIPTION
Added `chmod 644` to the SSH script before attempting `docker load` in `deploy.yml`. SCP transfers often create files with restrictive permissions or assign them root ownership, which causes docker to fail with `Permission denied` when attempting to read the tar file.