### PR TITLE
fix(ci): address docker save tar permission on runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Save Docker image to tar archive
-        run: docker save skill-hub:latest -o skill-hub-latest.tar
+        run: |
+          docker save skill-hub:latest -o skill-hub-latest.tar
+          sudo chmod 644 skill-hub-latest.tar
 
       - name: Copy files via SCP to Remote Server
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
The `docker save` command running in GitHub Actions creates the output `.tar` file with root ownership (because Docker runs as root). When the subsequent `appleboy/scp-action` attempts to read and tar the file for transfer, it fails with `Permission denied`.

Added `sudo chmod 644` to the tarball on the runner right after it is generated.