### PR TITLE
fix(ci): add missing checkout step in deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Copy docker-compose.prod.yml via SCP to Remote Server
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
The deploy job was failing with `tar: empty archive` during the SCP action. Because jobs in GitHub Actions run on fresh runners, the deploy job didn't have the source code checked out, meaning `docker-compose.prod.yml` didn't exist when SCP tried to send it. Added `actions/checkout@v4` as the first step in the deploy job.