### PR TITLE
fix: remove empty quotes causing unrecognized arguments in main.py

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -21,4 +21,4 @@ python main.py \
     --data-dir "${SKILL_HUB_DATA_DIR:-./data}" \
     --log-level "${SKILL_HUB_LOG_LEVEL:-INFO}" \
     --api-prefix "${SKILL_HUB_API_PREFIX:-/api}" \
-    "$([ "${SKILL_HUB_DEBUG:-false}" = "true" ] && echo "--debug")"
+    $([ "${SKILL_HUB_DEBUG:-false}" = "true" ] && echo "--debug")


### PR DESCRIPTION
Removed double quotes around the optional `--debug` flag in `start_server.sh`. When `SKILL_HUB_DEBUG` was false, this evaluated to `""` (an empty string argument), causing `argparse` in `main.py` to throw an unrecognized arguments error during container startup.