### PR TITLE
fix(pagination): return null next_cursor on last page

### DIFF
--- a/skill_hub/services/assistant_service.py
+++ b/skill_hub/services/assistant_service.py
@@ -166,7 +166,7 @@ class AssistantService:
         formatted_assistants = self._format_assistants(assistants)
 
         next_cursor = None
-        if formatted_assistants:
+        if has_more and formatted_assistants:
             last_assistant = formatted_assistants[-1]
             last_sort_order = last_assistant.sort_order
             last_created = last_assistant.created_at.isoformat() if last_assistant.created_at else ""

--- a/skill_hub/services/skill_service.py
+++ b/skill_hub/services/skill_service.py
@@ -242,7 +242,7 @@ class SkillService:
             cloned_skills = cloned_skills[:limit]
             
         next_cursor = None
-        if cloned_skills:
+        if has_more and cloned_skills:
             last_skill = cloned_skills[-1]
             last_sort = last_skill.sort_order if last_skill.sort_order is not None else 0
             last_id = str(last_skill.id)


### PR DESCRIPTION
## Problem

The cursor-pagination endpoints (`AssistantService.list_all_cursor`, `SkillService.list_all_cursor`) built a `next_cursor` whenever the result page was non-empty — **ignoring `has_more`**. As a result, the **final page** returned a non-null `next_cursor` even though `has_more` was `false`.

Verified live against two hubs:

```
ruigu_test:8080  limit=40 → returned:1  has_more:false  next_cursor: SET  ← should be null
default COS      limit=40 → returned:12 has_more:false  next_cursor: SET  ← should be null
```

Clients that paginate by following `next_cursor` (rather than stopping on `has_more`) fetch an extra page and re-receive the boundary row, inflating counts — e.g. a single assistant rendering as `count=2`.

## Fix

Only emit `next_cursor` when `has_more` is `true`, so a `null` cursor reliably signals the end of the result set.

- `skill_hub/services/assistant_service.py`: `if formatted_assistants:` → `if has_more and formatted_assistants:`
- `skill_hub/services/skill_service.py`: `if cloned_skills:` → `if has_more and cloned_skills:`

## Impact

- Consumers that loop on `has_more` (e.g. moss `batchSyncAssistants`) are unaffected.
- Consumers that loop on `next_cursor != null` now terminate correctly instead of re-fetching the last row.
- Default hub still returns all 12 assistants in a single page; single-page responses are unchanged except `next_cursor` is now correctly `null`.

## Notes

A separate latent defect remains (not addressed here): the keyset comparison casts `created_at` to string (`func.cast(Assistant.created_at, String) < cursor_created_at`), which can re-serve boundary rows when `limit` < total item count. Tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)